### PR TITLE
[ADD] cors settings to allow request sources from frontend domain

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -63,6 +63,7 @@ DJANGO_APPS = [
 ]
 
 THIRD_PARTY_APPS = [
+    "corsheaders",
     "django_celery_beat",
     "rest_framework",
 ]
@@ -108,6 +109,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/dev/ref/settings/#middleware
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -129,6 +129,12 @@ ANYMAIL = {
     "MAILGUN_API_URL": env("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
 }
 
+# CORS
+# -----------------------------------------------------------------------------
+# https://github.com/adamchainz/django-cors-headers
+CORS_ORIGIN_ALLOW_ALL = env.bool("DJANGO_CORS_ORIGIN_ALLOW_ALL", False)
+CORS_ORIGIN_WHITELIST = env.list("DJANGO_CORS_ORIGIN_WHITELIST", default=[])
+
 # LOGGING
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#logging

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,3 +10,4 @@ sentry-sdk==0.15.1  # https://github.com/getsentry/sentry-python
 # ------------------------------------------------------------------------------
 django-storages[boto3]==1.9.1  # https://github.com/jschneier/django-storages
 django-anymail[mailgun]==7.1.0  # https://github.com/anymail/django-anymail
+django-cors-headers==3.4.0 # https://github.com/adamchainz/django-cors-headers


### PR DESCRIPTION
Fix #26 
Using django-cors-headers to register allowed domains to request API resources.