### PR TITLE
[UPDATE] quit from settings BrokenLinkEmailMiddleware

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -116,7 +116,6 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.common.BrokenLinkEmailsMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,3 +19,4 @@ django-redis==4.12.1  # https://github.com/jazzband/django-redis
 # Django REST Framework
 djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework
 djangorestframework-simplejwt==4.4.0 # https://github.com/SimpleJWT/django-rest-framework-simplejwt
+django-cors-headers==3.4.0 # https://github.com/adamchainz/django-cors-headers

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,4 +10,3 @@ sentry-sdk==0.15.1  # https://github.com/getsentry/sentry-python
 # ------------------------------------------------------------------------------
 django-storages[boto3]==1.9.1  # https://github.com/jschneier/django-storages
 django-anymail[mailgun]==7.1.0  # https://github.com/anymail/django-anymail
-django-cors-headers==3.4.0 # https://github.com/adamchainz/django-cors-headers


### PR DESCRIPTION
quit from settings to avoid sent unnecessary emails. Error logging is sent to sentry.