### PR TITLE
[UPDATE] change recurrence field from CharField to RecurrenceField

### DIFF
--- a/subroutines/habits/serializers/habits.py
+++ b/subroutines/habits/serializers/habits.py
@@ -1,5 +1,7 @@
 from django.utils import timezone
 
+from recurrence import fields
+
 from rest_framework import serializers
 from subroutines.habits.models import Habit
 
@@ -8,7 +10,7 @@ class HabitSerializer(serializers.ModelSerializer):
     """Habit model serializer."""
 
     name = serializers.CharField(required=True)
-    recurrence = serializers.CharField(required=True)
+    recurrence = fields.RecurrenceField()
 
     class Meta:
 


### PR DESCRIPTION
Changed recurrence serializer field from serializer.CharField() to RecurrenceField() provided by django-recurrence to raise BadRequest error in the API with rest_framework when enter a no valid RRULE because before the error was propagated to low level and the error raised was server error.